### PR TITLE
Bigger default font, unserifed "10", and option to display suit next to rank

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.8.2"
+    version: "2.9.0"
   boolean_selector:
     dependency: transitive
     description:
@@ -21,28 +21,21 @@ packages:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
-  charcode:
-    dependency: transitive
-    description:
-      name: charcode
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.3.1"
+    version: "1.2.1"
   clock:
     dependency: transitive
     description:
       name: clock
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.1.1"
   collection:
     dependency: transitive
     description:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.15.0"
+    version: "1.16.0"
   cupertino_icons:
     dependency: "direct main"
     description:
@@ -56,7 +49,7 @@ packages:
       name: fake_async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.1"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -73,28 +66,28 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.11"
+    version: "0.12.12"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.3"
+    version: "0.1.5"
   meta:
     dependency: transitive
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.7.0"
+    version: "1.8.0"
   path:
     dependency: transitive
     description:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0"
+    version: "1.8.2"
   playing_cards:
     dependency: "direct main"
     description:
@@ -113,7 +106,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.1"
+    version: "1.9.0"
   stack_trace:
     dependency: transitive
     description:
@@ -134,34 +127,27 @@ packages:
       name: string_scanner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.1.1"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.2.1"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.8"
-  typed_data:
-    dependency: transitive
-    description:
-      name: typed_data
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.3.0"
+    version: "0.4.12"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.2"
 sdks:
-  dart: ">=2.14.0 <3.0.0"
+  dart: ">=2.17.0-0 <3.0.0"

--- a/lib/playing_cards.dart
+++ b/lib/playing_cards.dart
@@ -5,3 +5,4 @@ export 'src/views/playing-card-view.dart';
 export 'src/views/playing-card-view-style.dart';
 export 'src/model/deck.dart';
 export 'src/views/flat-card-fan.dart';
+export 'src/util/card-aspect-ratio.dart';

--- a/lib/src/model/deck.dart
+++ b/lib/src/model/deck.dart
@@ -1,6 +1,4 @@
 import 'package:playing_cards/playing_cards.dart';
-import 'package:playing_cards/src/model/playing-card.dart';
-import 'package:playing_cards/src/model/suit.dart';
 
 /// Generates a standard 52 card deck.
 List<PlayingCard> standardFiftyTwoCardDeck() {

--- a/lib/src/util/get-good-font-size.dart
+++ b/lib/src/util/get-good-font-size.dart
@@ -1,66 +1,54 @@
 import 'package:flutter/widgets.dart';
 
-double getGoodFontSize(String text, TextStyle style, double fitWidth) {
-  TextPainter textPainter = TextPainter(
-      text: TextSpan(text: text, style: style),
-      maxLines: 1,
-      textDirection: TextDirection.ltr);
-  textPainter.layout(minWidth: 0, maxWidth: double.infinity);
+/// Returns the largest fontSize where the given `text` takes no more than
+/// `fitSize` width (or no more than `fitSize` height, if `fitByHeight`) when
+/// using the given TextStyle (except for its fontSize).
+double getGoodFontSize(String text, TextStyle style, double fitSize,
+    {required bool fitByHeight}) {
+  double bestFontSizeSoFar = style.fontSize ?? 12;
 
-  double? minSize = style.fontSize;
-  double? maxSize = style.fontSize;
-  if (minSize == null) {
-    minSize = 12;
-  }
-  if (maxSize == null) {
-    maxSize = 12;
-  }
-
-  if (textPainter.size.width < fitWidth) {
-    while (textPainter.size.width < fitWidth) {
-      minSize = style.fontSize;
-      if (minSize == null) {
-        minSize = 12;
-      }
-      maxSize = minSize * 2;
-      style = style.copyWith(fontSize: maxSize);
-      textPainter = TextPainter(
-          text: TextSpan(text: text, style: style),
-          maxLines: 1,
-          textDirection: TextDirection.ltr);
-      textPainter.layout(minWidth: 0, maxWidth: double.infinity);
-    }
-  } else {
-    while (textPainter.size.width > fitWidth) {
-      maxSize = style.fontSize;
-      if (maxSize == null) {
-        maxSize = 12;
-      }
-      minSize = maxSize / 2;
-      style = style.copyWith(fontSize: minSize);
-      textPainter = TextPainter(
-          text: TextSpan(text: text, style: style),
-          maxLines: 1,
-          textDirection: TextDirection.ltr);
-      textPainter.layout(minWidth: 0, maxWidth: double.infinity);
-    }
-  }
-
-  // at this point, min is less and max is larger
-  while ((maxSize! - minSize!) > 3.0) {
-    double mid = minSize + (maxSize - minSize) / 2.0;
-    style = style.copyWith(fontSize: mid);
-    textPainter = TextPainter(
-        text: TextSpan(text: text, style: style),
+  // Returns the text's size (width or height) using the bestFontSizeSoFar.
+  double bestTextSizeSoFar() {
+    var bestStyleSoFar = style.copyWith(fontSize: bestFontSizeSoFar);
+    var textPainter = TextPainter(
+        text: TextSpan(text: text, style: bestStyleSoFar),
         maxLines: 1,
         textDirection: TextDirection.ltr);
     textPainter.layout(minWidth: 0, maxWidth: double.infinity);
-    if (textPainter.size.width < fitWidth) {
-      minSize = mid;
+    return fitByHeight ? textPainter.size.height : textPainter.size.width;
+  }
+
+  double? scaleBy;
+  while (true) {
+    var textSize = bestTextSizeSoFar();
+    if (textSize < fitSize) {
+      if (scaleBy == .5) break; // we were shrinking, now we're too small
+      scaleBy = 2.0; // we were at the start, or growing: keep growing
+    } else if (textSize > fitSize) {
+      if (scaleBy == 2.0) break; // we were growing, now we're too large
+      scaleBy = 0.5; // we were at the start, or shrinking: keep shrinking
     } else {
-      maxSize = mid;
+      return bestFontSizeSoFar; // perfect fit!
+    }
+    bestFontSizeSoFar *= scaleBy;
+  }
+  // We shrank/grew past fitSize.  Now binary search to find closest match
+  double minFontSize = bestFontSizeSoFar, maxFontSize = minFontSize / scaleBy!;
+  if (minFontSize > maxFontSize) {
+    double temp = minFontSize;
+    minFontSize = maxFontSize;
+    maxFontSize = temp;
+  }
+
+  // TODO: why 3 instead of 1?
+  while (maxFontSize - minFontSize > 3.0) {
+    bestFontSizeSoFar = (minFontSize + maxFontSize) / 2.0;
+    if (bestTextSizeSoFar() < fitSize) {
+      minFontSize = bestFontSizeSoFar;
+    } else {
+      maxFontSize = bestFontSizeSoFar;
     }
   }
 
-  return minSize;
+  return minFontSize; // err on the side of fitting within fitSize
 }

--- a/lib/src/util/get-good-font-size.dart
+++ b/lib/src/util/get-good-font-size.dart
@@ -40,7 +40,6 @@ double getGoodFontSize(String text, TextStyle style, double fitSize,
     maxFontSize = temp;
   }
 
-  // TODO: why 3 instead of 1?
   while (maxFontSize - minFontSize > 3.0) {
     bestFontSizeSoFar = (minFontSize + maxFontSize) / 2.0;
     if (bestTextSizeSoFar() < fitSize) {

--- a/lib/src/util/get-good-font-size.dart
+++ b/lib/src/util/get-good-font-size.dart
@@ -1,30 +1,28 @@
 import 'package:flutter/widgets.dart';
 
 /// Returns the largest fontSize where the given `text` takes no more than
-/// `fitSize` width (or no more than `fitSize` height, if `fitByHeight`) when
-/// using the given TextStyle (except for its fontSize).
-double getGoodFontSize(String text, TextStyle style, double fitSize,
-    {required bool fitByHeight}) {
+/// `fitWidth` width when using the given TextStyle (except for its fontSize).
+double getGoodFontSize(String text, TextStyle style, double fitWidth) {
   double bestFontSizeSoFar = style.fontSize ?? 12;
 
-  // Returns the text's size (width or height) using the bestFontSizeSoFar.
-  double bestTextSizeSoFar() {
+  // Returns the text's width using the bestFontSizeSoFar.
+  double bestTextWidthSoFar() {
     var bestStyleSoFar = style.copyWith(fontSize: bestFontSizeSoFar);
     var textPainter = TextPainter(
         text: TextSpan(text: text, style: bestStyleSoFar),
         maxLines: 1,
         textDirection: TextDirection.ltr);
     textPainter.layout(minWidth: 0, maxWidth: double.infinity);
-    return fitByHeight ? textPainter.size.height : textPainter.size.width;
+    return textPainter.size.width;
   }
 
   double? scaleBy;
   while (true) {
-    var textSize = bestTextSizeSoFar();
-    if (textSize < fitSize) {
+    var textWidth = bestTextWidthSoFar();
+    if (textWidth < fitWidth) {
       if (scaleBy == .5) break; // we were shrinking, now we're too small
       scaleBy = 2.0; // we were at the start, or growing: keep growing
-    } else if (textSize > fitSize) {
+    } else if (textWidth > fitWidth) {
       if (scaleBy == 2.0) break; // we were growing, now we're too large
       scaleBy = 0.5; // we were at the start, or shrinking: keep shrinking
     } else {
@@ -32,7 +30,7 @@ double getGoodFontSize(String text, TextStyle style, double fitSize,
     }
     bestFontSizeSoFar *= scaleBy;
   }
-  // We shrank/grew past fitSize.  Now binary search to find closest match
+  // We shrank/grew past fitWidth.  Now binary search to find closest match
   double minFontSize = bestFontSizeSoFar, maxFontSize = minFontSize / scaleBy!;
   if (minFontSize > maxFontSize) {
     double temp = minFontSize;
@@ -42,12 +40,12 @@ double getGoodFontSize(String text, TextStyle style, double fitSize,
 
   while (maxFontSize - minFontSize > 3.0) {
     bestFontSizeSoFar = (minFontSize + maxFontSize) / 2.0;
-    if (bestTextSizeSoFar() < fitSize) {
+    if (bestTextWidthSoFar() < fitWidth) {
       minFontSize = bestFontSizeSoFar;
     } else {
       maxFontSize = bestFontSizeSoFar;
     }
   }
 
-  return minFontSize; // err on the side of fitting within fitSize
+  return minFontSize; // err on the side of fitting within fitWidth
 }

--- a/lib/src/util/internal-playing-card-extensions.dart
+++ b/lib/src/util/internal-playing-card-extensions.dart
@@ -20,7 +20,7 @@ extension CardValueExtension on CardValue {
       case CardValue.nine:
         return "9";
       case CardValue.ten:
-        return "10";
+        return "I0";
       case CardValue.jack:
         return "J";
       case CardValue.queen:

--- a/lib/src/views/default-playing-card-styles.dart
+++ b/lib/src/views/default-playing-card-styles.dart
@@ -25,10 +25,14 @@ Map<Suit, Widget Function(BuildContext context)> defaultJackBuilders = {
       package: 'playing_cards', filterQuality: FilterQuality.high),
 };
 
-var defaultBwJokerBuilder = (context) => Image.asset("assets/card_imagery/bw_joker.png",
-      package: 'playing_cards', filterQuality: FilterQuality.high);
-var defaultColorJokerBuilder = (context) => Image.asset("assets/card_imagery/color_joker.png",
-      package: 'playing_cards', filterQuality: FilterQuality.high); 
+var defaultBwJokerBuilder = (context) => Image.asset(
+    "assets/card_imagery/bw_joker.png",
+    package: 'playing_cards',
+    filterQuality: FilterQuality.high);
+var defaultColorJokerBuilder = (context) => Image.asset(
+    "assets/card_imagery/color_joker.png",
+    package: 'playing_cards',
+    filterQuality: FilterQuality.high);
 
 Map<Suit, Widget Function(BuildContext context)> defaultQueenBuilders = {
   Suit.clubs: (context) => Image.asset("assets/card_imagery/qc.png",
@@ -72,12 +76,14 @@ Map<CardValue, Widget Function(BuildContext context)?> getContentBuilders(
         ? overrides[val]
         : (context) => RankCardCenter(rank: val.rank, suitBuilder: suitBuilder);
   }
-  contentBuilders[CardValue.joker_1] = overrides != null && overrides.containsKey(CardValue.joker_1)
-      ? overrides[CardValue.joker_1]
-      : defaultBwJokerBuilder;
-  contentBuilders[CardValue.joker_2] = overrides != null && overrides.containsKey(CardValue.joker_2)
-      ? overrides[CardValue.joker_2]
-      : defaultColorJokerBuilder;
+  contentBuilders[CardValue.joker_1] =
+      overrides != null && overrides.containsKey(CardValue.joker_1)
+          ? overrides[CardValue.joker_1]
+          : defaultBwJokerBuilder;
+  contentBuilders[CardValue.joker_2] =
+      overrides != null && overrides.containsKey(CardValue.joker_2)
+          ? overrides[CardValue.joker_2]
+          : defaultColorJokerBuilder;
   contentBuilders[CardValue.jack] =
       overrides != null && overrides.containsKey(CardValue.jack)
           ? overrides[CardValue.jack]
@@ -125,7 +131,8 @@ PlayingCardViewStyle defaultPlayingCardStyles = PlayingCardViewStyle(
         "assets/card_imagery/back_001.png",
         fit: BoxFit.fill,
         package: 'playing_cards',
-        filterQuality: FilterQuality.high));
+        filterQuality: FilterQuality.high),
+    suitBesideLabel: false);
 
 SuitStyle _reconcileSuitStyle(
     Suit suit, SuitStyle? defaultSuitStyle, SuitStyle suitStyle) {
@@ -158,5 +165,6 @@ PlayingCardViewStyle reconcileStyle(PlayingCardViewStyle? style) {
       suitStyles: suitStyles,
       cardBackContentBuilder: style.cardBackContentBuilder == null
           ? defaultPlayingCardStyles.cardBackContentBuilder
-          : style.cardBackContentBuilder);
+          : style.cardBackContentBuilder,
+      suitBesideLabel: style.suitBesideLabel ?? false);
 }

--- a/lib/src/views/default-playing-card-styles.dart
+++ b/lib/src/views/default-playing-card-styles.dart
@@ -1,7 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:playing_cards/playing_cards.dart';
-import 'package:playing_cards/src/model/suit.dart';
-import 'package:playing_cards/src/views/playing-card-view-style.dart';
 import 'package:playing_cards/src/views/rank-card-center.dart';
 import 'package:playing_cards/src/util/internal-playing-card-extensions.dart';
 

--- a/lib/src/views/playing-card-content-view.dart
+++ b/lib/src/views/playing-card-content-view.dart
@@ -20,6 +20,8 @@ class PlayingCardContentView extends StatelessWidget {
   @override
   Widget build(BuildContext context) =>
       LayoutBuilder(builder: (context, constraints) {
+        bool suitBesideLabel = false;
+
         double width = constraints.hasBoundedWidth
             ? constraints.maxWidth
             : constraints.maxHeight * playingCardAspectRatio;
@@ -33,24 +35,29 @@ class PlayingCardContentView extends StatelessWidget {
         double sideSpace = (width - innerWidth) / 2.0;
         double suitHeight = height * 0.160714;
         double labelSuitHeight = suitHeight / 2.0;
+        double sideOffset = 0;
         double topOffset = height * 0.030714;
 
         TextStyle ts = valueTextStyle!.copyWith(
-            fontSize: getGoodFontSize("I0", valueTextStyle!, sideSpace * .9,
-                fitByHeight: false));
+            fontSize: getGoodFontSize("I0", valueTextStyle!, sideSpace * .9));
 
-        List<Widget> labelAndSuit = [
-          Text(valueText!,
-              style: ts,
-              maxLines: 1,
-              softWrap: false,
-              textAlign: TextAlign.center),
-          Container(
-              height: labelSuitHeight,
-              width: sideSpace,
-              child: suitBuilder!(context)),
-        ];
-        Widget cornerContainer = Column(children: labelAndSuit);
+        Widget label = Text(valueText!,
+            style: ts,
+            maxLines: 1,
+            softWrap: false,
+            textAlign: TextAlign.center);
+        Widget suit = Container(
+            height: labelSuitHeight,
+            child: suitBuilder!(context));
+        // Text has half-leaders that provide good spacing b/w label and suit
+        Widget cornerContainer = Container(width: sideSpace, child: Column(children: [label, suit]));
+
+        if (suitBesideLabel) {
+          cornerContainer = Container(child: Row(children: [label, SizedBox(width: width * 0.02), suit]));
+          sideOffset = width * 0.036; // can't rely on centering in sideSpace
+          innerWidth *= 0.90; // give clearance for suit across the top
+          innerHeight *= 0.90; // maintain aspect ratio
+        }
 
         return Stack(children: [
           Align(
@@ -61,16 +68,14 @@ class PlayingCardContentView extends StatelessWidget {
                   child: center != null ? center!(context) : Container())),
           // Top label and suit
           Positioned(
-            left: 0,
+            left: sideOffset,
             top: topOffset,
-            width: sideSpace,
             child: cornerContainer,
           ),
           // Bottom label and suit
           Positioned(
-            right: 0,
+            right: sideOffset,
             bottom: topOffset,
-            width: sideSpace,
             child: RotatedBox(
               quarterTurns: 2,
               child: cornerContainer,

--- a/lib/src/views/playing-card-content-view.dart
+++ b/lib/src/views/playing-card-content-view.dart
@@ -31,12 +31,27 @@ class PlayingCardContentView extends StatelessWidget {
         double innerWidth = width * 1.6875 / 2.5;
         double innerHeight = height * 2.8125 / 3.5;
         double sideSpace = (width - innerWidth) / 2.0;
-        double labelHeight = height * 0.089285;
         double suitHeight = height * 0.160714;
         double labelSuitHeight = suitHeight / 2.0;
+        double topOffset = height * 0.030714;
 
         TextStyle ts = valueTextStyle!.copyWith(
-            fontSize: getGoodFontSize("10", valueTextStyle!, sideSpace * .9));
+            fontSize: getGoodFontSize("I0", valueTextStyle!, sideSpace * .9,
+                fitByHeight: false));
+
+        List<Widget> labelAndSuit = [
+          Text(valueText!,
+              style: ts,
+              maxLines: 1,
+              softWrap: false,
+              textAlign: TextAlign.center),
+          Container(
+              height: labelSuitHeight,
+              width: sideSpace,
+              child: suitBuilder!(context)),
+        ];
+        Widget cornerContainer = Column(children: labelAndSuit);
+
         return Stack(children: [
           Align(
               alignment: Alignment(0, 0),
@@ -44,46 +59,23 @@ class PlayingCardContentView extends StatelessWidget {
                   width: innerWidth,
                   height: innerHeight,
                   child: center != null ? center!(context) : Container())),
+          // Top label and suit
           Positioned(
-              left: 0,
-              top: height * 0.035714,
-              width: sideSpace,
-              height: labelHeight,
-              child: Text(
-                valueText!,
-                style: ts,
-                maxLines: 1,
-                softWrap: false,
-                overflow: TextOverflow.visible,
-                textAlign: TextAlign.center,
-              )),
+            left: 0,
+            top: topOffset,
+            width: sideSpace,
+            child: cornerContainer,
+          ),
+          // Bottom label and suit
           Positioned(
-              right: 0,
-              bottom: height * 0.035714 + labelHeight + height * .01,
-              width: sideSpace,
-              height: labelSuitHeight,
-              child: RotatedBox(quarterTurns: 2, child: suitBuilder!(context))),
-          Positioned(
-              right: 0,
-              bottom: height * 0.035714,
-              width: sideSpace,
-              height: labelHeight,
-              child: RotatedBox(
-                  quarterTurns: 2,
-                  child: Text(
-                    valueText!,
-                    style: ts,
-                    maxLines: 1,
-                    softWrap: false,
-                    overflow: TextOverflow.visible,
-                    textAlign: TextAlign.center,
-                  ))),
-          Positioned(
-              left: 0,
-              top: height * 0.035714 + labelHeight + height * .01,
-              width: sideSpace,
-              height: labelSuitHeight,
-              child: suitBuilder!(context)),
+            right: 0,
+            bottom: topOffset,
+            width: sideSpace,
+            child: RotatedBox(
+              quarterTurns: 2,
+              child: cornerContainer,
+            ),
+          ),
         ]);
       });
 }

--- a/lib/src/views/playing-card-content-view.dart
+++ b/lib/src/views/playing-card-content-view.dart
@@ -47,13 +47,19 @@ class PlayingCardContentView extends StatelessWidget {
             softWrap: false,
             textAlign: TextAlign.center);
         Widget suit = Container(
-            height: labelSuitHeight,
-            child: suitBuilder!(context));
+          height: labelSuitHeight,
+          child: suitBuilder!(context),
+        );
         // Text has half-leaders that provide good spacing b/w label and suit
-        Widget cornerContainer = Container(width: sideSpace, child: Column(children: [label, suit]));
+        Widget cornerContainer =
+            Container(width: sideSpace, child: Column(children: [label, suit]));
 
         if (suitBesideLabel) {
-          cornerContainer = Container(child: Row(children: [label, SizedBox(width: width * 0.02), suit]));
+          cornerContainer = Container(
+            child: Row(
+              children: [label, SizedBox(width: width * 0.02), suit],
+            ),
+          );
           sideOffset = width * 0.036; // can't rely on centering in sideSpace
           innerWidth *= 0.90; // give clearance for suit across the top
           innerHeight *= 0.90; // maintain aspect ratio

--- a/lib/src/views/playing-card-content-view.dart
+++ b/lib/src/views/playing-card-content-view.dart
@@ -8,20 +8,20 @@ class PlayingCardContentView extends StatelessWidget {
   final TextStyle? valueTextStyle;
   final Widget Function(BuildContext context)? suitBuilder;
   final Widget Function(BuildContext context)? center;
+  final bool? suitBesideLabel;
 
   const PlayingCardContentView(
       {Key? key,
       this.valueText,
       this.valueTextStyle,
       this.suitBuilder,
-      this.center})
+      this.center,
+      this.suitBesideLabel})
       : super(key: key);
 
   @override
   Widget build(BuildContext context) =>
       LayoutBuilder(builder: (context, constraints) {
-        bool suitBesideLabel = false;
-
         double width = constraints.hasBoundedWidth
             ? constraints.maxWidth
             : constraints.maxHeight * playingCardAspectRatio;
@@ -54,7 +54,7 @@ class PlayingCardContentView extends StatelessWidget {
         Widget cornerContainer =
             Container(width: sideSpace, child: Column(children: [label, suit]));
 
-        if (suitBesideLabel) {
+        if (suitBesideLabel!) {
           cornerContainer = Container(
             child: Row(
               children: [label, SizedBox(width: width * 0.02), suit],

--- a/lib/src/views/playing-card-view-style.dart
+++ b/lib/src/views/playing-card-view-style.dart
@@ -33,6 +33,12 @@ class PlayingCardViewStyle {
   /// The back of the card.
   final Widget Function(BuildContext context)? cardBackContentBuilder;
 
+  /// True if the suit should appear to the right of the label in the corder
+  /// of the card, false if the suit should appear below the label.  Defaults
+  /// to false.
+  final bool? suitBesideLabel;
+
   /// Creates a style. One style can be used for an entire deck.
-  const PlayingCardViewStyle({this.suitStyles, this.cardBackContentBuilder});
+  const PlayingCardViewStyle(
+      {this.suitStyles, this.cardBackContentBuilder, this.suitBesideLabel});
 }

--- a/lib/src/views/playing-card-view.dart
+++ b/lib/src/views/playing-card-view.dart
@@ -55,6 +55,7 @@ class PlayingCardView extends StatelessWidget {
         suitBuilder: reconciled.suitStyles![card.suit]!.builder,
         center:
             reconciled.suitStyles![card.suit]!.cardContentBuilders![card.value],
+        suitBesideLabel: reconciled.suitBesideLabel,
       );
     }
 

--- a/lib/src/views/playing-card-view.dart
+++ b/lib/src/views/playing-card-view.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:flutter/widgets.dart';
 import 'package:playing_cards/src/model/playing-card.dart';
 import 'package:playing_cards/src/util/card-aspect-ratio.dart';
 import 'package:playing_cards/src/views/default-playing-card-styles.dart';

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.8.2"
+    version: "2.9.0"
   boolean_selector:
     dependency: transitive
     description:
@@ -21,35 +21,28 @@ packages:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
-  charcode:
-    dependency: transitive
-    description:
-      name: charcode
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.3.1"
+    version: "1.2.1"
   clock:
     dependency: transitive
     description:
       name: clock
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.1.1"
   collection:
     dependency: transitive
     description:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.15.0"
+    version: "1.16.0"
   fake_async:
     dependency: transitive
     description:
       name: fake_async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.1"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -66,28 +59,28 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.11"
+    version: "0.12.12"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.3"
+    version: "0.1.5"
   meta:
     dependency: transitive
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.7.0"
+    version: "1.8.0"
   path:
     dependency: transitive
     description:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0"
+    version: "1.8.2"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -99,7 +92,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.1"
+    version: "1.9.0"
   stack_trace:
     dependency: transitive
     description:
@@ -120,34 +113,27 @@ packages:
       name: string_scanner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.1.1"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.2.1"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.8"
-  typed_data:
-    dependency: transitive
-    description:
-      name: typed_data
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.3.0"
+    version: "0.4.12"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.2"
 sdks:
-  dart: ">=2.14.0 <3.0.0"
+  dart: ">=2.17.0-0 <3.0.0"


### PR DESCRIPTION
Hi! Thanks for making this package.  I have made a few improvements that I hope you'll like!

1) The default font is too small compared to actual cards online.  It was nigh on illegible when viewing all 52 cards in a solitaire game.  I understand this is because we have to have a consistent font size, and we had to fit the widest text "10" in the side space, so all other text suffers.  If Flutter came with multiple default fonts, we could pick a font closer to a normal narrow playing card font, but Roboto is all we've got, with its wide characters and its serifed "1".

So I replaced "10" with "I0" (capital i, zero) instead, both on the rank 10 card and in the getGoodFontSize calculation.  Now "I0" takes as much width as "10" did before, but can be a larger font.  The result is that all other cards are much more legible and closer to the size one would see on a real deck of cards (and the "10" is unserifed just like on real cards.)

2) I am writing a Freecell solitaire game, which requires vertical cascades of cards where you have to see the suit.  Putting the suit to the right of the rank, rather than below it, would allow much more overlap between cards -- you only have to see the top little bit of the card to know its rank AND suit.  I added a suitBesideLabel style option, defaulting to false, that lets the cards display the suit next to the rank instead, and in which the card center is rendered slightly smaller so the suit doesn't overlap with it.

Note that with the font size change, the magic numbers no longer strictly are based on measurements of real cards, as your comment reports.  I didn't change the comment though :)

3) I thought I would need getGoodFontSize to support either fit by height or fit by width, before I realized fit by width would work just fine even when suitBesideLabel is true.  By the time I realized it, I had refactored getGoodFontSize.  I've left the refactor in place because it's less code, commented a little more, and I think simpler to follow.  Let me know if I should revert that file instead.

4) I did some drive-by fixing of warnings reported by VS Code (removing redundant imports) and let VS Code do some reformatting to match the default Flutter formatter.  I actually don't know how to NOT reformat upon save in VS Code (I'm new to this IDE) :)

5) I haven't added the flag to the docs yet as I wasn't sure if you'd accept it.  If so I'd be happy to take a crack at that as well.

Sorry that I rolled 2 features and some code cleanup into a single PR!  If you'd rather they come separately I can do that too.