### PR TITLE
Align last card of the fan in the center

### DIFF
--- a/lib/src/views/flat-card-fan.dart
+++ b/lib/src/views/flat-card-fan.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/widgets.dart';
-import 'dart:math';
 
 /// This widget will array the passed in children in a horizontal line.
 /// The children will overlap such that the available space is filled
@@ -19,7 +18,10 @@ class FlatCardFan extends StatelessWidget {
             children.length,
             (index) => Align(
                   alignment: Alignment(
-                      -1.0 + (index / max(children.length - 1, 1)) * 2.0, 0),
+                      children.length > 1
+                          ? -1.0 + (index / (children.length - 1)) * 2.0
+                          : 0,
+                      0),
                   child: children[index],
                 )),
       );


### PR DESCRIPTION
When using `FlatCardFan`, I've got crashes with one card left in the fan. Researching further, I've noticed that there is a fix for that in commit 625de71.
Applying this fix locally, I've noticed another issue: behavior wasn't consistent between one card and more then one card. It's aligned on the left, but it should be aligned in the center.
The reason is because when `children.length == 1`  `(-1.0 + (index / max(children.length - 1, 1)) * 2.0) == -1`  and it should be `0` instead. 
I've failed to come up with expression that would produce desired output, so I've resorted to a simple check, which fixed the issue.